### PR TITLE
Remove highlighted text

### DIFF
--- a/index.html
+++ b/index.html
@@ -195,7 +195,6 @@
 <body>
     <div class="header">
         <h1>Jakarta Interactive Map with Overpass Query</h1>
-        <p>Powered by OpenStreetMap, Leaflet.js & Overpass API</p>
     </div>
     
     <div class="map-container">


### PR DESCRIPTION
The subtitle "Powered by OpenStreetMap, Leaflet.js & Overpass API" was removed from the `index.html` file.

*   The text was located within a `<p>` tag inside the `<div class="header">`.
*   This modification was performed to remove the specific subtitle text identified as being directly below the main HTML page title.
*   As a result, the map interface now displays only the primary title, "Jakarta Interactive Map with Overpass Query", without the accompanying subtitle.